### PR TITLE
Updated dependencies attribute of metadata to be empty array

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,4 +13,5 @@ galaxy_info:
    - java
    - jboss
    - eap
+dependencies: []
 


### PR DESCRIPTION
Fix for galaxy import failure, the galaxy import expects empty dependencies in meta/main.yml for successful import