### PR TITLE
Added http/https/ftp jboss artifact download method.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,4 +20,4 @@ jboss_eap_bind_management_address: 0.0.0.0
 jboss_eap_base_version: 6.4
 
 # ussually this is set at the playbook level
-#transfer_method: # csp-to-host | copy-from-contoller
+#transfer_method: # csp-to-host | copy-from-contoller | url

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -110,6 +110,52 @@
 
 #### Download and install base library and patch
 
+- name: Async Download JBoss EAP Patch by URL (HTTP/HTTPS/FTP)
+  get_url:
+    url: "{{ jboss_eap_patch_artifact_url }}"
+    dest: "{{ jboss_eap_patch_dest }}"
+    url_username: "{{ url_username | default(None) }}"
+    url_password: "{{ url_password | default(None) }}"
+  async: 7200
+  poll: 0
+  register: url_jboss_eap_patch_download
+  tags:
+    - jboss_eap
+  when: transfer_method == 'url' and jboss_eap_apply_patch == true and (jboss_eap_exists.stat.exists == false or 'base' in patch_info_result.stdout)
+
+- name: Async Download JBoss EAP by URL (HTTP/HTTPS/FTP)
+  get_url:
+    url: "{{ jboss_eap_artifact_url }}"
+    dest: "{{ jboss_eap_artifact_dl_dest }}"
+    url_username: "{{ url_username | default(None) }}"
+    url_password: "{{ url_password | default(None) }}"
+  async: 7200
+  poll: 0
+  register: url_jboss_eap_download
+  tags:
+    - jboss_eap
+  when: transfer_method == 'url' and jboss_eap_exists.stat.exists == false
+
+- name: Check On JBoss EAP Download Completion (URL)
+  async_status: jid={{ url_jboss_eap_download.ansible_job_id }}
+  register: job_result1
+  until: job_result1.finished
+  retries: 600
+  delay: 10
+  tags:
+    - jboss_eap
+  when: transfer_method == 'url' and jboss_eap_exists.stat.exists == false
+
+- name: Check On JBoss EAP Patch Download Completion (URL)
+  async_status: jid={{ url_jboss_eap_patch_download.ansible_job_id }}
+  register: job_result2
+  until: job_result2.finished
+  retries: 600
+  delay: 10
+  tags:
+    - jboss_eap
+  when: transfer_method == 'url' and jboss_eap_apply_patch == true and (jboss_eap_exists.stat.exists == false or 'base' in patch_info_result.stdout)
+
 - name: Async Download JBoss EAP Patch from Red Hat Customer Portal
   redhat_csp_download:
     url: "{{ jboss_eap_patch_artifact_url }}"
@@ -118,7 +164,7 @@
     password: "{{ rhn_password }}"
   async: 7200
   poll: 0
-  register: jboss_eap_patch_download
+  register: csp_jboss_eap_patch_download
   tags:
     - jboss_eap
   when: transfer_method == 'csp-to-host' and jboss_eap_apply_patch == true and (jboss_eap_exists.stat.exists == false or 'base' in patch_info_result.stdout)
@@ -131,13 +177,13 @@
     password: "{{ rhn_password }}"
   async: 7200
   poll: 0
-  register: jboss_eap_download
+  register: csp_jboss_eap_download
   tags:
     - jboss_eap
   when: transfer_method == 'csp-to-host' and jboss_eap_exists.stat.exists == false
 
-- name: 'Check On JBoss EAP Download Completion'
-  async_status: jid={{ jboss_eap_download.ansible_job_id }}
+- name: Check On JBoss EAP Download Completion (CSP)
+  async_status: jid={{ csp_jboss_eap_download.ansible_job_id }}
   register: job_result1
   until: job_result1.finished
   retries: 600
@@ -146,8 +192,8 @@
     - jboss_eap
   when: transfer_method == 'csp-to-host' and jboss_eap_exists.stat.exists == false
 
-- name: 'Check On JBoss EAP Patch Download Completion'
-  async_status: jid={{ jboss_eap_patch_download.ansible_job_id }}
+- name: Check On JBoss EAP Patch Download Completion (CSP)
+  async_status: jid={{ csp_jboss_eap_patch_download.ansible_job_id }}
   register: job_result2
   until: job_result2.finished
   retries: 600


### PR DESCRIPTION
This change introduces a new download method for jboss
artifacts called 'url' that allows using either http, https, or ftp
as an artifact source.

One goal with this change was to reduce the number of
additional variables needed to specify by projects depending
on this role. Here is an example set of group_vars that show
how to use this new download method:

```
transfer_method: url
jboss_eap_artifact_source: https://my-file-server/jboss-eap-6.4.0.zip
jboss_eap_patch_artifact_source: https://my-file-server/jboss-eap-6.4.7-patch.zip
jboss_eap_artifact_name: jboss-eap-6.4.0.zip
jboss_eap_patch_artifact_name: jboss-eap-6.4.7-patch.zip
jboss_eap_apply_patch: yes
```