### PR TITLE
Adding changes to fix deprecated issues with Ansible 2.9

### DIFF
--- a/tasks/apply_patch.yml
+++ b/tasks/apply_patch.yml
@@ -28,7 +28,7 @@
   register: url_jboss_eap_patch_download
   tags:
     - jboss_eap
-  when: transfer_method == 'url' and (not jboss_eap_exists.stat.exists | bool or 'base' in patch_info_result.stdout)
+  when: transfer_method == 'url' and (not jboss_eap_exists.stat.exists | bool or patch_info_result is defined)
 
 - name: Check On JBoss EAP Patch Download Completion (URL)
   async_status: jid={{ url_jboss_eap_patch_download.ansible_job_id }}
@@ -38,7 +38,7 @@
   delay: 10
   tags:
     - jboss_eap
-  when: transfer_method == 'url' and (not jboss_eap_exists.stat.exists | bool or 'base' in patch_info_result.stdout)
+  when: transfer_method == 'url' and (not jboss_eap_exists.stat.exists | bool or patch_info_result is defined)
 
 - name: Async Download JBoss EAP Patch from Red Hat Customer Portal
   redhat_csp_download:
@@ -51,7 +51,8 @@
   register: csp_jboss_eap_patch_download
   tags:
     - jboss_eap
-  when: transfer_method == 'csp-to-host' and jboss_eap_apply_patch | bool and (not jboss_eap_exists.stat.exists | bool or 'base' in patch_info_result.stdout)
+  when:
+    - transfer_method == 'csp-to-host' and jboss_eap_apply_patch | bool and (not jboss_eap_exists.stat.exists | bool or (patch_info_result is defined and patch_info_result is defined))
 
 - name: Check On JBoss EAP Patch Download Completion (CSP)
   async_status: jid={{ csp_jboss_eap_patch_download.ansible_job_id }}
@@ -61,13 +62,13 @@
   delay: 10
   tags:
     - jboss_eap
-  when: transfer_method == 'csp-to-host' and (not jboss_eap_exists.stat.exists | bool or 'base' in patch_info_result.stdout)
+  when: transfer_method == 'csp-to-host' and (not jboss_eap_exists.stat.exists | bool or patch_info_result is defined)
 
 - name: Copy JBoss EAP Patch
   copy:
     src: "{{ jboss_eap_patch_artifact_name }}"
     dest: "{{ jboss_eap_patch_dest }}"
-  when: transfer_method == 'copy-from-controller' and (not jboss_eap_exists.stat.exists | bool or 'base' in patch_info_result.stdout)
+  when: transfer_method == 'copy-from-controller' and (not jboss_eap_exists.stat.exists | bool or patch_info_result is defined)
 
 - name: Determine current JBoss EAP patch info
   become_user: "{{ jboss_eap_user }}"

--- a/tasks/jboss_instance.yml
+++ b/tasks/jboss_instance.yml
@@ -30,7 +30,7 @@
     jboss_eap_service_conf_file: "{{ jboss_eap_service_conf_dir }}/jboss-{{ instance_name }}.conf"
     jboss_eap_runtime_conf_src_file: "{{ jboss_eap_bin_dir }}/{{ instance_mode }}.conf"
     jboss_eap_runtime_conf_file: "{{ jboss_eap_bin_dir }}/{{ jboss_eap_runtime_conf_filename }}"
-    jboss_eap_service_src_file: "{{ (jboss_eap_base_version is version_compare('7.0','<')) | ternary('jboss-as-'+instance_mode+'.sh','jboss-eap-rhel.sh') }}"
+    jboss_eap_service_src_file: "{{ (jboss_eap_base_version is version('7.0','<')) | ternary('jboss-as-'+instance_mode+'.sh','jboss-eap-rhel.sh') }}"
     jboss_eap_initd_service_file: "/etc/init.d/{{ jboss_eap_service_file }}"
     jboss_eap_pid_file: "{{ jboss_eap_service_data_dir }}/jboss-{{ instance_name }}/jboss-{{ instance_name }}.pid"
 
@@ -189,7 +189,7 @@
 - name: Set JBoss EAP Service Name EL 6
   set_fact:
     jboss_eap_service_name: "{{ jboss_eap_service_file }}"
-  when: (ansible_distribution_major_version is version_compare('6','<='))
+  when: (ansible_distribution_major_version is version('6','<='))
 
 ##
 # RHEL 7 expects init.d service without extension
@@ -197,7 +197,7 @@
 - name: Set JBoss EAP Service Name EL 7
   set_fact:
     jboss_eap_service_name: "{{ jboss_eap_service_file | splitext | first }}"
-  when: (ansible_distribution_major_version is version_compare('7','>='))
+  when: (ansible_distribution_major_version is version('7','>='))
 
 - name: "Enable {{ jboss_eap_service_file }} Service"
   become: true


### PR DESCRIPTION
version_compare is deprecated in Ansible 2.9. Changes added and tested it. Please see http://pastebin.test.redhat.com/891332